### PR TITLE
Fix deployiment script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "serve": "vue-cli-service serve --copy",
     "build": "vue-cli-service build --modern",
-    "deploy": "npm run build && cp CNAME ./dist && cd ./dist && npx surge && cd ..",
+    "deploy": "npm run build && cp CNAME ./dist && cd ./dist && cp index.html 200.html && npx surge && cd ..",
     "lint": "eclint check $(git ls-files) && vue-cli-service lint",
     "test:unit": "vue-cli-service test:unit"
   },

--- a/public/200.html
+++ b/public/200.html
@@ -1,1 +1,0 @@
-<meta http-equiv="refresh" content="0; url='/'">


### PR DESCRIPTION
The redirect was working only for 404. Better to copy `index.html` to `200.html` and avoid further issues.